### PR TITLE
use correct macro 'robotiq-3f-gripper_articulated'

### DIFF
--- a/robots/lwr_robotiq_3finger.urdf.xacro
+++ b/robots/lwr_robotiq_3finger.urdf.xacro
@@ -11,7 +11,7 @@
 
   <!-- Robotiq 3 finger hand -->
   <xacro:include filename="$(find robotiq_3f_gripper_visualization)/cfg/robotiq-3f-gripper_articulated_macro.xacro" />
-	<xacro:robotiq-3f-gripper_finger_articulated prefix="robotiq_"/>
+	<xacro:robotiq-3f-gripper_articulated prefix="robotiq_"/>
 
   <!-- connector with thread, length: 22mm -->
   <joint name="lwr_connector_joint" type="fixed">


### PR DESCRIPTION
I used the wrong macro while renaming to the new robotiq package.