### PR TITLE
Fix world_frame conflict with EXOTica, add SRDFs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ set(xacro_files
 
 xacro_add_files(${xacro_files} INORDER REMAP collision_simple:=0 TARGET media_files INSTALL DESTINATION urdf)
 
+install(DIRECTORY srdf
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
 foreach(dir meshes)
     install(DIRECTORY ${dir}/
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${dir})

--- a/srdf/lwr.srdf
+++ b/srdf/lwr.srdf
@@ -1,0 +1,54 @@
+<?xml version="1.0" ?>
+<!--This does not replace URDF, and is not an extension of URDF.
+    This is a format for representing semantic information about the robot structure.
+    A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
+-->
+<robot name="lwr">
+    <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
+    <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
+    <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
+    <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
+    <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
+    <group name="arm">
+        <joint name="lwr_arm_0_joint" />
+        <joint name="lwr_arm_1_joint" />
+        <joint name="lwr_arm_2_joint" />
+        <joint name="lwr_arm_3_joint" />
+        <joint name="lwr_arm_4_joint" />
+        <joint name="lwr_arm_5_joint" />
+        <joint name="lwr_arm_6_joint" />
+    </group>
+    <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
+    <virtual_joint name="world_joint" type="fixed" parent_frame="world_frame" child_link="table" />
+    <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+    <disable_collisions link1="base" link2="lwr_arm_1_link" reason="Adjacent" />
+    <disable_collisions link1="base" link2="lwr_arm_2_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_3_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="base" link2="table" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_2_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_3_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="table" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_3_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="table" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_4_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="table" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_arm_5_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="lwr_arm_6_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_5_link" link2="lwr_arm_7_link" reason="Default" />
+    <disable_collisions link1="lwr_arm_6_link" link2="lwr_arm_7_link" reason="Adjacent" />
+</robot>

--- a/srdf/lwr_ft.srdf
+++ b/srdf/lwr_ft.srdf
@@ -1,0 +1,68 @@
+<?xml version="1.0" ?>
+<!--This does not replace URDF, and is not an extension of URDF.
+    This is a format for representing semantic information about the robot structure.
+    A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
+-->
+<robot name="lwr">
+    <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
+    <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
+    <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
+    <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
+    <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
+    <group name="arm">
+        <joint name="lwr_arm_0_joint" />
+        <joint name="lwr_arm_1_joint" />
+        <joint name="lwr_arm_2_joint" />
+        <joint name="lwr_arm_3_joint" />
+        <joint name="lwr_arm_4_joint" />
+        <joint name="lwr_arm_5_joint" />
+        <joint name="lwr_arm_6_joint" />
+    </group>
+    <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
+    <virtual_joint name="world_joint" type="fixed" parent_frame="world_frame" child_link="table" />
+    <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+    <disable_collisions link1="base" link2="lwr_arm_1_link" reason="Adjacent" />
+    <disable_collisions link1="base" link2="lwr_arm_2_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_3_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="base" link2="table" reason="Adjacent" />
+    <disable_collisions link1="contact_point" link2="force_torque_sensor" reason="Adjacent" />
+    <disable_collisions link1="contact_point" link2="lwr_arm_2_link" reason="Never" />
+    <disable_collisions link1="contact_point" link2="lwr_arm_3_link" reason="Never" />
+    <disable_collisions link1="contact_point" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="contact_point" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="contact_point" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="contact_point" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="force_torque_sensor" link2="lwr_arm_2_link" reason="Never" />
+    <disable_collisions link1="force_torque_sensor" link2="lwr_arm_3_link" reason="Never" />
+    <disable_collisions link1="force_torque_sensor" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="force_torque_sensor" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="force_torque_sensor" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="force_torque_sensor" link2="lwr_arm_7_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_2_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_3_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="table" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_3_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="table" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_4_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="table" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_arm_5_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="lwr_arm_6_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_5_link" link2="lwr_arm_7_link" reason="Default" />
+    <disable_collisions link1="lwr_arm_6_link" link2="lwr_arm_7_link" reason="Adjacent" />
+</robot>

--- a/srdf/lwr_pen.srdf
+++ b/srdf/lwr_pen.srdf
@@ -1,0 +1,79 @@
+<?xml version="1.0" ?>
+<!--This does not replace URDF, and is not an extension of URDF.
+    This is a format for representing semantic information about the robot structure.
+    A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
+-->
+<robot name="lwr">
+    <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
+    <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
+    <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
+    <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
+    <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
+    <group name="arm">
+        <joint name="lwr_arm_0_joint" />
+        <joint name="lwr_arm_1_joint" />
+        <joint name="lwr_arm_2_joint" />
+        <joint name="lwr_arm_3_joint" />
+        <joint name="lwr_arm_4_joint" />
+        <joint name="lwr_arm_5_joint" />
+        <joint name="lwr_arm_6_joint" />
+    </group>
+    <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
+    <virtual_joint name="world_joint" type="fixed" parent_frame="world_frame" child_link="table" />
+    <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+    <disable_collisions link1="base" link2="lwr_arm_1_link" reason="Adjacent" />
+    <disable_collisions link1="base" link2="lwr_arm_2_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_3_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="base" link2="table" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_2_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_3_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="pen_base_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="pen_ori_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="pen_tip_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="table" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_3_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="pen_base_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="pen_ori_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="pen_tip_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="table" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_4_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="pen_base_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="pen_ori_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="pen_tip_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="table" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_arm_5_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="pen_base_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="pen_ori_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="pen_tip_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="lwr_arm_6_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_5_link" link2="lwr_arm_7_link" reason="Default" />
+    <disable_collisions link1="lwr_arm_5_link" link2="pen_base_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="pen_ori_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="pen_tip_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="lwr_arm_7_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_6_link" link2="pen_base_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="pen_ori_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="pen_tip_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="pen_base_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_7_link" link2="pen_ori_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_7_link" link2="pen_tip_link" reason="Never" />
+    <disable_collisions link1="pen_base_link" link2="pen_ori_link" reason="Default" />
+    <disable_collisions link1="pen_base_link" link2="pen_tip_link" reason="Adjacent" />
+    <disable_collisions link1="pen_ori_link" link2="pen_tip_link" reason="Never" />
+</robot>

--- a/srdf/lwr_robotiq_3finger.srdf
+++ b/srdf/lwr_robotiq_3finger.srdf
@@ -1,0 +1,250 @@
+<?xml version="1.0" ?>
+<!--This does not replace URDF, and is not an extension of URDF.
+    This is a format for representing semantic information about the robot structure.
+    A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
+-->
+<robot name="lwr">
+    <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
+    <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
+    <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
+    <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
+    <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
+    <group name="arm">
+        <joint name="lwr_arm_0_joint" />
+        <joint name="lwr_arm_1_joint" />
+        <joint name="lwr_arm_2_joint" />
+        <joint name="lwr_arm_3_joint" />
+        <joint name="lwr_arm_4_joint" />
+        <joint name="lwr_arm_5_joint" />
+        <joint name="lwr_arm_6_joint" />
+    </group>
+    <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
+    <virtual_joint name="world_joint" type="fixed" parent_frame="world_frame" child_link="table" />
+    <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+    <disable_collisions link1="base" link2="lwr_arm_1_link" reason="Adjacent" />
+    <disable_collisions link1="base" link2="lwr_arm_2_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_3_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_connector" reason="Never" />
+    <disable_collisions link1="base" link2="table" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_2_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_3_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_connector" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="robotiq_connector" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="robotiq_coupling" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="robotiq_finger_1_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="table" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_3_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_connector" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="robotiq_connector" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="robotiq_coupling" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="robotiq_finger_1_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="robotiq_finger_2_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="robotiq_finger_2_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="robotiq_finger_middle_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="robotiq_finger_middle_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="robotiq_finger_middle_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="robotiq_palm" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="table" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_4_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_connector" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="robotiq_connector" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="robotiq_coupling" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="robotiq_finger_1_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="robotiq_finger_1_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="robotiq_finger_1_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="robotiq_finger_1_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="robotiq_finger_2_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="robotiq_finger_2_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="robotiq_finger_2_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="robotiq_finger_2_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="robotiq_finger_middle_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="robotiq_finger_middle_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="robotiq_finger_middle_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="robotiq_palm" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="table" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_arm_5_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_connector" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="robotiq_connector" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="robotiq_coupling" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="robotiq_finger_1_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="robotiq_finger_1_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="robotiq_finger_1_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="robotiq_finger_1_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="robotiq_finger_2_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="robotiq_finger_2_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="robotiq_finger_2_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="robotiq_finger_2_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="robotiq_finger_middle_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="robotiq_finger_middle_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="robotiq_finger_middle_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="robotiq_palm" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="lwr_arm_6_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_5_link" link2="lwr_arm_7_link" reason="Default" />
+    <disable_collisions link1="lwr_arm_5_link" link2="lwr_connector" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="robotiq_connector" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="robotiq_coupling" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="robotiq_finger_1_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="robotiq_finger_1_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="robotiq_finger_1_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="robotiq_finger_1_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="robotiq_finger_2_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="robotiq_finger_2_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="robotiq_finger_2_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="robotiq_finger_2_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="robotiq_finger_middle_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="robotiq_finger_middle_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="robotiq_finger_middle_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="robotiq_palm" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="lwr_arm_7_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_6_link" link2="lwr_connector" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="robotiq_connector" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="robotiq_coupling" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="robotiq_finger_1_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="robotiq_finger_1_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="robotiq_finger_1_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="robotiq_finger_1_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="robotiq_finger_2_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="robotiq_finger_2_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="robotiq_finger_2_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="robotiq_finger_2_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="robotiq_finger_middle_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="robotiq_finger_middle_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="robotiq_finger_middle_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="robotiq_palm" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="lwr_connector" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_7_link" link2="robotiq_connector" reason="Default" />
+    <disable_collisions link1="lwr_arm_7_link" link2="robotiq_coupling" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="robotiq_finger_1_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="robotiq_finger_1_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="robotiq_finger_1_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="robotiq_finger_1_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="robotiq_finger_2_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="robotiq_finger_2_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="robotiq_finger_2_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="robotiq_finger_2_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="robotiq_finger_middle_link_1" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="robotiq_finger_middle_link_2" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="robotiq_finger_middle_link_3" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="robotiq_palm" reason="Never" />
+    <disable_collisions link1="lwr_connector" link2="robotiq_connector" reason="Adjacent" />
+    <disable_collisions link1="lwr_connector" link2="robotiq_coupling" reason="Never" />
+    <disable_collisions link1="lwr_connector" link2="robotiq_finger_1_link_0" reason="Never" />
+    <disable_collisions link1="lwr_connector" link2="robotiq_finger_1_link_1" reason="Never" />
+    <disable_collisions link1="lwr_connector" link2="robotiq_finger_1_link_2" reason="Never" />
+    <disable_collisions link1="lwr_connector" link2="robotiq_finger_1_link_3" reason="Never" />
+    <disable_collisions link1="lwr_connector" link2="robotiq_finger_2_link_0" reason="Never" />
+    <disable_collisions link1="lwr_connector" link2="robotiq_finger_2_link_1" reason="Never" />
+    <disable_collisions link1="lwr_connector" link2="robotiq_finger_2_link_2" reason="Never" />
+    <disable_collisions link1="lwr_connector" link2="robotiq_finger_2_link_3" reason="Never" />
+    <disable_collisions link1="lwr_connector" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="lwr_connector" link2="robotiq_finger_middle_link_1" reason="Never" />
+    <disable_collisions link1="lwr_connector" link2="robotiq_finger_middle_link_2" reason="Never" />
+    <disable_collisions link1="lwr_connector" link2="robotiq_finger_middle_link_3" reason="Never" />
+    <disable_collisions link1="lwr_connector" link2="robotiq_palm" reason="Never" />
+    <disable_collisions link1="robotiq_connector" link2="robotiq_coupling" reason="Adjacent" />
+    <disable_collisions link1="robotiq_connector" link2="robotiq_finger_1_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_connector" link2="robotiq_finger_1_link_1" reason="Never" />
+    <disable_collisions link1="robotiq_connector" link2="robotiq_finger_1_link_2" reason="Never" />
+    <disable_collisions link1="robotiq_connector" link2="robotiq_finger_1_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_connector" link2="robotiq_finger_2_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_connector" link2="robotiq_finger_2_link_1" reason="Never" />
+    <disable_collisions link1="robotiq_connector" link2="robotiq_finger_2_link_2" reason="Never" />
+    <disable_collisions link1="robotiq_connector" link2="robotiq_finger_2_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_connector" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_connector" link2="robotiq_finger_middle_link_1" reason="Never" />
+    <disable_collisions link1="robotiq_connector" link2="robotiq_finger_middle_link_2" reason="Never" />
+    <disable_collisions link1="robotiq_connector" link2="robotiq_finger_middle_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_connector" link2="robotiq_palm" reason="Never" />
+    <disable_collisions link1="robotiq_coupling" link2="robotiq_finger_1_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_coupling" link2="robotiq_finger_1_link_1" reason="Never" />
+    <disable_collisions link1="robotiq_coupling" link2="robotiq_finger_1_link_2" reason="Never" />
+    <disable_collisions link1="robotiq_coupling" link2="robotiq_finger_1_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_coupling" link2="robotiq_finger_2_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_coupling" link2="robotiq_finger_2_link_1" reason="Never" />
+    <disable_collisions link1="robotiq_coupling" link2="robotiq_finger_2_link_2" reason="Never" />
+    <disable_collisions link1="robotiq_coupling" link2="robotiq_finger_2_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_coupling" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_coupling" link2="robotiq_finger_middle_link_1" reason="Never" />
+    <disable_collisions link1="robotiq_coupling" link2="robotiq_finger_middle_link_2" reason="Never" />
+    <disable_collisions link1="robotiq_coupling" link2="robotiq_finger_middle_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_coupling" link2="robotiq_palm" reason="Adjacent" />
+    <disable_collisions link1="robotiq_finger_1_link_0" link2="robotiq_finger_1_link_1" reason="Adjacent" />
+    <disable_collisions link1="robotiq_finger_1_link_0" link2="robotiq_finger_1_link_2" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_0" link2="robotiq_finger_1_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_0" link2="robotiq_finger_2_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_0" link2="robotiq_finger_2_link_1" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_0" link2="robotiq_finger_2_link_2" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_0" link2="robotiq_finger_2_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_0" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_0" link2="robotiq_finger_middle_link_1" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_0" link2="robotiq_finger_middle_link_2" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_0" link2="robotiq_finger_middle_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_0" link2="robotiq_palm" reason="Adjacent" />
+    <disable_collisions link1="robotiq_finger_1_link_1" link2="robotiq_finger_1_link_2" reason="Adjacent" />
+    <disable_collisions link1="robotiq_finger_1_link_1" link2="robotiq_finger_1_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_1" link2="robotiq_finger_2_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_1" link2="robotiq_finger_2_link_1" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_1" link2="robotiq_finger_2_link_2" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_1" link2="robotiq_finger_2_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_1" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_1" link2="robotiq_finger_middle_link_1" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_1" link2="robotiq_palm" reason="Default" />
+    <disable_collisions link1="robotiq_finger_1_link_2" link2="robotiq_finger_1_link_3" reason="Adjacent" />
+    <disable_collisions link1="robotiq_finger_1_link_2" link2="robotiq_finger_2_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_2" link2="robotiq_finger_2_link_1" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_2" link2="robotiq_finger_2_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_2" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_2" link2="robotiq_palm" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_3" link2="robotiq_finger_2_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_3" link2="robotiq_finger_2_link_1" reason="Never" />
+    <disable_collisions link1="robotiq_finger_1_link_3" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_finger_2_link_0" link2="robotiq_finger_2_link_1" reason="Adjacent" />
+    <disable_collisions link1="robotiq_finger_2_link_0" link2="robotiq_finger_2_link_2" reason="Never" />
+    <disable_collisions link1="robotiq_finger_2_link_0" link2="robotiq_finger_2_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_finger_2_link_0" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_finger_2_link_0" link2="robotiq_finger_middle_link_1" reason="Never" />
+    <disable_collisions link1="robotiq_finger_2_link_0" link2="robotiq_finger_middle_link_2" reason="Never" />
+    <disable_collisions link1="robotiq_finger_2_link_0" link2="robotiq_finger_middle_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_finger_2_link_0" link2="robotiq_palm" reason="Adjacent" />
+    <disable_collisions link1="robotiq_finger_2_link_1" link2="robotiq_finger_2_link_2" reason="Adjacent" />
+    <disable_collisions link1="robotiq_finger_2_link_1" link2="robotiq_finger_2_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_finger_2_link_1" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_finger_2_link_1" link2="robotiq_finger_middle_link_1" reason="Never" />
+    <disable_collisions link1="robotiq_finger_2_link_1" link2="robotiq_palm" reason="Default" />
+    <disable_collisions link1="robotiq_finger_2_link_2" link2="robotiq_finger_2_link_3" reason="Adjacent" />
+    <disable_collisions link1="robotiq_finger_2_link_2" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_finger_2_link_2" link2="robotiq_palm" reason="Never" />
+    <disable_collisions link1="robotiq_finger_2_link_3" link2="robotiq_finger_middle_link_0" reason="Never" />
+    <disable_collisions link1="robotiq_finger_middle_link_0" link2="robotiq_finger_middle_link_1" reason="Adjacent" />
+    <disable_collisions link1="robotiq_finger_middle_link_0" link2="robotiq_finger_middle_link_2" reason="Never" />
+    <disable_collisions link1="robotiq_finger_middle_link_0" link2="robotiq_finger_middle_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_finger_middle_link_0" link2="robotiq_palm" reason="Adjacent" />
+    <disable_collisions link1="robotiq_finger_middle_link_1" link2="robotiq_finger_middle_link_2" reason="Adjacent" />
+    <disable_collisions link1="robotiq_finger_middle_link_1" link2="robotiq_finger_middle_link_3" reason="Never" />
+    <disable_collisions link1="robotiq_finger_middle_link_1" link2="robotiq_palm" reason="Default" />
+    <disable_collisions link1="robotiq_finger_middle_link_2" link2="robotiq_finger_middle_link_3" reason="Adjacent" />
+    <disable_collisions link1="robotiq_finger_middle_link_2" link2="robotiq_palm" reason="Never" />
+</robot>

--- a/srdf/lwr_sdh.srdf
+++ b/srdf/lwr_sdh.srdf
@@ -1,0 +1,186 @@
+<?xml version="1.0" ?>
+<!--This does not replace URDF, and is not an extension of URDF.
+    This is a format for representing semantic information about the robot structure.
+    A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
+-->
+<robot name="lwr">
+    <!--GROUPS: Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
+    <!--LINKS: When a link is specified, the parent joint of that link (if it exists) is automatically included-->
+    <!--JOINTS: When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
+    <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
+    <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
+    <group name="arm">
+        <joint name="lwr_arm_0_joint" />
+        <joint name="lwr_arm_1_joint" />
+        <joint name="lwr_arm_2_joint" />
+        <joint name="lwr_arm_3_joint" />
+        <joint name="lwr_arm_4_joint" />
+        <joint name="lwr_arm_5_joint" />
+        <joint name="lwr_arm_6_joint" />
+    </group>
+    <group name="sdh">
+        <joint name="sdh_knuckle_joint" />
+        <joint name="sdh_finger_12_joint" />
+        <joint name="sdh_finger_13_joint" />
+        <joint name="sdh_thumb_1_joint" />
+        <joint name="sdh_thumb_2_joint" />
+        <joint name="sdh_thumb_3_joint" />
+        <joint name="sdh_finger_21_joint" />
+        <joint name="sdh_finger_22_joint" />
+        <joint name="sdh_finger_23_joint" />
+    </group>
+    <group name="arm_sdh">
+        <joint name="lwr_arm_0_joint" />
+        <joint name="lwr_arm_1_joint" />
+        <joint name="lwr_arm_2_joint" />
+        <joint name="lwr_arm_3_joint" />
+        <joint name="lwr_arm_4_joint" />
+        <joint name="lwr_arm_5_joint" />
+        <joint name="lwr_arm_6_joint" />
+        <joint name="sdh_finger_21_joint" />
+        <joint name="sdh_finger_22_joint" />
+        <joint name="sdh_finger_23_joint" />
+        <joint name="sdh_finger_12_joint" />
+        <joint name="sdh_finger_13_joint" />
+        <joint name="sdh_thumb_1_joint" />
+        <joint name="sdh_thumb_2_joint" />
+        <joint name="sdh_thumb_3_joint" />
+    </group>
+    <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
+    <virtual_joint name="world_joint" type="fixed" parent_frame="world_frame" child_link="table" />
+    <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
+    <disable_collisions link1="base" link2="lwr_arm_1_link" reason="Adjacent" />
+    <disable_collisions link1="base" link2="lwr_arm_2_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_3_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="base" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="base" link2="table" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_2_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_3_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="sdh_finger_11_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="sdh_finger_12_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="sdh_finger_21_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="sdh_grasp_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="sdh_palm_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="sdh_thumb_1_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_1_link" link2="table" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_3_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_4_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="sdh_finger_11_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="sdh_finger_12_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="sdh_finger_21_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="sdh_finger_22_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="sdh_grasp_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="sdh_palm_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="sdh_thumb_1_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="sdh_thumb_2_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="sdh_tip_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_2_link" link2="table" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_4_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_5_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="sdh_finger_11_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="sdh_finger_12_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="sdh_finger_13_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="sdh_finger_21_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="sdh_finger_22_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="sdh_finger_23_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="sdh_grasp_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="sdh_palm_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="sdh_thumb_1_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="sdh_thumb_2_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="sdh_thumb_3_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="sdh_tip_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_3_link" link2="table" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_arm_5_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_arm_6_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="lwr_arm_7_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="sdh_finger_11_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="sdh_finger_12_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="sdh_finger_21_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="sdh_finger_22_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="sdh_grasp_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="sdh_palm_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="sdh_thumb_1_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="sdh_thumb_2_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_4_link" link2="sdh_tip_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="lwr_arm_6_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_5_link" link2="lwr_arm_7_link" reason="Default" />
+    <disable_collisions link1="lwr_arm_5_link" link2="sdh_finger_11_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="sdh_finger_12_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="sdh_finger_21_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="sdh_finger_22_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="sdh_grasp_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="sdh_palm_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="sdh_thumb_1_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="sdh_thumb_2_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_5_link" link2="sdh_tip_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="lwr_arm_7_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_6_link" link2="sdh_finger_11_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="sdh_finger_12_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="sdh_finger_13_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="sdh_finger_21_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="sdh_finger_22_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="sdh_finger_23_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="sdh_grasp_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="sdh_palm_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="sdh_thumb_1_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="sdh_thumb_2_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="sdh_thumb_3_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_6_link" link2="sdh_tip_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="sdh_finger_11_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="sdh_finger_12_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="sdh_finger_13_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="sdh_finger_21_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="sdh_finger_22_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="sdh_finger_23_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="sdh_grasp_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="sdh_palm_link" reason="Adjacent" />
+    <disable_collisions link1="lwr_arm_7_link" link2="sdh_thumb_1_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="sdh_thumb_2_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="sdh_thumb_3_link" reason="Never" />
+    <disable_collisions link1="lwr_arm_7_link" link2="sdh_tip_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_11_link" link2="sdh_finger_12_link" reason="Adjacent" />
+    <disable_collisions link1="sdh_finger_11_link" link2="sdh_finger_13_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_11_link" link2="sdh_finger_21_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_11_link" link2="sdh_grasp_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_11_link" link2="sdh_palm_link" reason="Adjacent" />
+    <disable_collisions link1="sdh_finger_11_link" link2="sdh_thumb_1_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_11_link" link2="sdh_tip_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_12_link" link2="sdh_finger_13_link" reason="Adjacent" />
+    <disable_collisions link1="sdh_finger_12_link" link2="sdh_palm_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_12_link" link2="sdh_tip_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_13_link" link2="sdh_grasp_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_21_link" link2="sdh_finger_22_link" reason="Adjacent" />
+    <disable_collisions link1="sdh_finger_21_link" link2="sdh_finger_23_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_21_link" link2="sdh_grasp_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_21_link" link2="sdh_palm_link" reason="Adjacent" />
+    <disable_collisions link1="sdh_finger_21_link" link2="sdh_thumb_1_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_21_link" link2="sdh_thumb_3_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_21_link" link2="sdh_tip_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_22_link" link2="sdh_finger_23_link" reason="Adjacent" />
+    <disable_collisions link1="sdh_finger_22_link" link2="sdh_palm_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_22_link" link2="sdh_tip_link" reason="Never" />
+    <disable_collisions link1="sdh_finger_23_link" link2="sdh_grasp_link" reason="Never" />
+    <disable_collisions link1="sdh_grasp_link" link2="sdh_palm_link" reason="Adjacent" />
+    <disable_collisions link1="sdh_grasp_link" link2="sdh_thumb_1_link" reason="Never" />
+    <disable_collisions link1="sdh_grasp_link" link2="sdh_thumb_3_link" reason="Never" />
+    <disable_collisions link1="sdh_grasp_link" link2="sdh_tip_link" reason="Never" />
+    <disable_collisions link1="sdh_palm_link" link2="sdh_thumb_1_link" reason="Adjacent" />
+    <disable_collisions link1="sdh_palm_link" link2="sdh_thumb_2_link" reason="Never" />
+    <disable_collisions link1="sdh_palm_link" link2="sdh_tip_link" reason="Adjacent" />
+    <disable_collisions link1="sdh_thumb_1_link" link2="sdh_thumb_2_link" reason="Adjacent" />
+    <disable_collisions link1="sdh_thumb_1_link" link2="sdh_thumb_3_link" reason="Never" />
+    <disable_collisions link1="sdh_thumb_1_link" link2="sdh_tip_link" reason="Never" />
+    <disable_collisions link1="sdh_thumb_2_link" link2="sdh_thumb_3_link" reason="Adjacent" />
+    <disable_collisions link1="sdh_thumb_2_link" link2="sdh_tip_link" reason="Never" />
+</robot>

--- a/urdf/lwr.urdf.xacro
+++ b/urdf/lwr.urdf.xacro
@@ -12,7 +12,7 @@
   </xacro:if>
   <xacro:include filename="$(find kuka_lwr4_description)/urdf/defs/materials.xml"/>
 
-  <link name="world_frame">
+  <link name="table">
       <visual>
         <origin xyz="0 0 -0.02" rpy="0 0 0"/>
         <geometry>
@@ -28,7 +28,7 @@
       </collision>
   </link>
 
-  <kuka_lwr_arm parent="world_frame" name="lwr" right="1" gazebo="$(arg use_gazebo)" transmission="$(arg use_transmission)" collisionsimple="$(arg collision_simple)" visualsimple="$(arg visual_simple)">
+  <kuka_lwr_arm parent="table" name="lwr" right="1" gazebo="$(arg use_gazebo)" transmission="$(arg use_transmission)" collisionsimple="$(arg collision_simple)" visualsimple="$(arg visual_simple)">
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </kuka_lwr_arm>
 


### PR DESCRIPTION
1. Adds basic SRDF for all URDFs in the repository right now. While technically not directly part of a description, we do work over and over recreating these (without all the other MoveIt config stuff). 
2. Renames ``world_frame`` to ``table`` as it actually represents the table in the lab. ``world_frame`` is a virtual frame (from the virtual ``world_joint``) in EXOTica so this clashes. 

cc @christian-rauch @VladimirIvan 